### PR TITLE
Use youtube-nocookie for better user privacy.

### DIFF
--- a/music_app/templates/music_app/get.html
+++ b/music_app/templates/music_app/get.html
@@ -16,8 +16,9 @@
     {% endtimezone %}
     <br>
     <div class="row">
-        <!-- 1. The <iframe> (and video player) will replace this <div> tag. -->
-        <div id="player"></div>
+        <iframe id="player" type="text/html" width="640" height="390"
+                src="http://www.youtube-nocookie.com/embed/{{entry.link}}?enablejsapi=1&origin=http://{{domain}}"
+                frameborder="0"></iframe>
     </div>
 
     <script>
@@ -33,9 +34,6 @@
       var player;
       function onYouTubeIframeAPIReady() {
         player = new YT.Player('player', {
-          height: '390',
-          width: '640',
-          videoId: '{{entry.link}}',
           events: {
             'onReady': onPlayerReady,
             'onStateChange': onPlayerStateChange,

--- a/music_app/views.py
+++ b/music_app/views.py
@@ -17,8 +17,8 @@ def getm(request, musicid):
     if musicid == 0:
         musicid = 1
     entry = getitem(musicid)
-    return render(request, "music_app/get.html", {'id': musicid, 'entry': entry})  # entry might be None, handled in
-    # template
+    # entry might be None, handled in template
+    return render(request, "music_app/get.html", {'id': musicid, 'entry': entry, 'domain': request.get_host()})
 
 
 @csrf_exempt


### PR DESCRIPTION
This creates the iframe directly using www.youtube-nocookie.com. The `&origin=` parameter, which prevents XSS attacks or something, requires passing in our domain name.