### PR TITLE
Iframe embed fixes

### DIFF
--- a/music_app/templates/music_app/get.html
+++ b/music_app/templates/music_app/get.html
@@ -17,7 +17,7 @@
     <br>
     <div class="row">
         <iframe id="player" type="text/html" width="640" height="390"
-                src="http://www.youtube-nocookie.com/embed/{{entry.link}}?enablejsapi=1&origin=http://{{domain}}"
+                src="http://www.youtube-nocookie.com/embed/{{entry.link}}?enablejsapi=1&origin=http://{{domain}}&rel=0&playsinline=1"
                 frameborder="0"></iframe>
     </div>
 


### PR DESCRIPTION
- rel=0: Related videos are not shown in the player when the video is paused
- playsinline=1: On iOS, videos play inline, instead of fullscreen by default.