### PR TITLE
/latest now redirects to the "canonical URL" of the submission

### DIFF
--- a/music_app/views.py
+++ b/music_app/views.py
@@ -2,7 +2,8 @@ import re
 
 import requests
 from django.http import HttpResponse, JsonResponse
-from django.shortcuts import render
+from django.shortcuts import redirect, render
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 
@@ -68,4 +69,4 @@ def num(request):
 
 @csrf_exempt
 def latest(request):
-    return getm(request, Music.objects.count())
+    return redirect(reverse('get music', kwargs={'musicid': Music.objects.count()}))


### PR DESCRIPTION
Previously, something like http://telegramusic.ml/latest/ would go to the latest submission, but the url in the web browser would still display as `http://telegramusic.ml/latest/`. Now, it will redirect and display as something like `http://telegramusic.ml/6/`, based on whatever the newest ID is.